### PR TITLE
[IMP] hr_attendance_missing_days: don't break on multi work day attendances

### DIFF
--- a/hr_attendance_contract_missing_days/tests/__init__.py
+++ b/hr_attendance_contract_missing_days/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_hr_attendance_contract_missing_days

--- a/hr_attendance_contract_missing_days/tests/test_hr_attendance_contract_missing_days.py
+++ b/hr_attendance_contract_missing_days/tests/test_hr_attendance_contract_missing_days.py
@@ -1,0 +1,23 @@
+from odoo.addons.hr_attendance_missing_days.tests import test_attendance
+
+
+class TestAttendance(test_attendance.TestAttendance):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.contract = cls.env["hr.contract"].create(
+            {
+                "name": "2023",
+                "date_start": "2023-01-01",
+                "date_end": "2023-12-31",
+                "state": "open",
+                "wage": 42,
+                "employee_id": cls.employee.id,
+            }
+        )
+
+    def _clone_employee(self, employee, defaults):
+        result = super()._clone_employee(employee, defaults)
+        for contract in employee.contract_ids:
+            contract.copy({"employee_id": result.id, "state": "open"})
+        return result

--- a/hr_attendance_missing_days/models/hr_employee.py
+++ b/hr_attendance_missing_days/models/hr_employee.py
@@ -79,6 +79,9 @@ class Employee(models.Model):
         attendances = {
             ensure_tz(attendance.check_in, tz).date()
             for attendance in self.attendance_ids.filtered_domain(domain)
+        } | {
+            ensure_tz(attendance.check_out, tz).date()
+            for attendance in self.attendance_ids.filtered_domain(domain)
         }
 
         vals = []

--- a/hr_attendance_missing_days/models/hr_employee.py
+++ b/hr_attendance_missing_days/models/hr_employee.py
@@ -76,12 +76,11 @@ class Employee(models.Model):
             ("check_in", ">=", dt_from.replace(tzinfo=None)),
             ("check_in", "<=", dt_to.replace(tzinfo=None)),
         ]
+        attendance_records = self.attendance_ids.filtered_domain(domain)
         attendances = {
-            ensure_tz(attendance.check_in, tz).date()
-            for attendance in self.attendance_ids.filtered_domain(domain)
-        } | {
-            ensure_tz(attendance.check_out, tz).date()
-            for attendance in self.attendance_ids.filtered_domain(domain)
+            ensure_tz(attendance_date, tz).date()
+            for attendance_date in attendance_records.mapped("check_in")
+            + attendance_records.mapped("check_out")
         }
 
         vals = []

--- a/hr_attendance_missing_days/tests/test_attendance.py
+++ b/hr_attendance_missing_days/tests/test_attendance.py
@@ -109,3 +109,21 @@ class TestAttendance(TransactionCase):
 
         attendances_new = attendances_after - attendances_before
         self.assertFalse(attendances_new)
+
+    def test_multi_day_attendance(self):
+        """Test that having an attendance crossing a day border doesn't break"""
+        self.employee.tz = "Europe/Amsterdam"
+        attendance = self.env["hr.attendance"].create(
+            {
+                "employee_id": self.employee.id,
+                "check_in": "2023-12-18 21:00:00",
+                "check_out": "2023-12-19 13:00:00",
+            }
+        )
+        self.employee._create_missing_attendances(
+            date(2023, 12, 18), date(2023, 12, 19)
+        )
+        self.assertEqual(
+            self.env["hr.attendance"].search([("employee_id", "=", self.employee.id)]),
+            attendance,
+        )

--- a/hr_attendance_missing_days/tests/test_attendance.py
+++ b/hr_attendance_missing_days/tests/test_attendance.py
@@ -60,7 +60,9 @@ class TestAttendance(TransactionCase):
 
         attended = {date(2023, 7, 3 + offset) for offset in range(4)}
         for tz in ["Europe/Amsterdam", "Pacific/Auckland", "America/New_York"]:
-            employee = self.employee.copy({"tz": tz, "name": f"Employee {tz}"})
+            employee = self._clone_employee(
+                self.employee, {"tz": tz, "name": f"Employee {tz}"}
+            )
             for offset, times in enumerate(((0, 30), (23, 30), (11, 30), (12, 30))):
                 # Convert the times from the employee TZ zo UTC. 3rd is monday
                 start = convert_tz(
@@ -127,3 +129,6 @@ class TestAttendance(TransactionCase):
             self.env["hr.attendance"].search([("employee_id", "=", self.employee.id)]),
             attendance,
         )
+
+    def _clone_employee(self, employee, defaults):
+        return employee.copy(defaults)


### PR DESCRIPTION
@fkantelberg thanks again for this. We ran into an issue when an attendance spans multiple days in the work calendar, here my proposed fix plus test case.

While being on it, I took the liberty to add another commit adding a test for `hr_attendance_contract_missing_days`, hoping greenness will trigger the good people of hr-attendance maintainers to merge the PR.